### PR TITLE
新規記事ページを作成

### DIFF
--- a/doshisha-media-app/app/admin/posts/new/page.tsx
+++ b/doshisha-media-app/app/admin/posts/new/page.tsx
@@ -146,7 +146,7 @@ export default function NewPostPage() {
                                 value="draft"
                                 checked={status === "draft"}
                                 onChange={(e) =>
-                                    setStatus(e.target.value as "draft")
+                                    setStatus(e.target.value as "draft" | "published")
                                 }
                                 className="mr-2 text-indigo-600 focus:ring-indigo-500"
                             />
@@ -158,7 +158,7 @@ export default function NewPostPage() {
                                 value="published"
                                 checked={status === "published"}
                                 onChange={(e) =>
-                                    setStatus(e.target.value as "published")
+                                    setStatus(e.target.value as "draft" | "published")
                                 }
                                 className="mr-2 text-indigo-600 focus:ring-indigo-500"
                             />


### PR DESCRIPTION
## 概要  
管理者が新規投稿を作成できる管理画面を追加しました。タイトル、カテゴリ、Markdownエディタ付きの本文、ステータスを入力できるフォームを実装し、認証チェックやバリデーションも組み込んでいます。  

## 主な変更点  

* `doshisha-media-app/app/admin/posts/new/page.tsx` に `NewPostPage` コンポーネントを追加  
  - タイトル、カテゴリ、本文（Markdownエディタ使用）、ステータスを入力できる新規投稿フォームを実装  
* NextAuth の `useSession` を利用して認証をチェックし、未認証ユーザーはログインページへリダイレクトするように変更  
* フォームのバリデーション、エラーハンドリング、投稿データを `/api/posts` に送信して成功時にリダイレクトする処理を実装  
* Markdownエディタ（`@uiw/react-md-editor`）を動的インポートし、クライアントサイドレンダリングのみに対応  
* エラー表示、ローディング状態、管理画面への戻りリンクなど UI を追加  
